### PR TITLE
restrict claims to intersection of token and resource server scopes

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunIntrospectionResultAssembler.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunIntrospectionResultAssembler.java
@@ -1,8 +1,8 @@
 package cz.muni.ics.oidc;
 
+import com.google.common.collect.Sets;
 import com.google.gson.JsonElement;
 import org.mitre.oauth2.model.OAuth2AccessTokenEntity;
-import org.mitre.oauth2.model.OAuth2RefreshTokenEntity;
 import org.mitre.oauth2.service.impl.DefaultIntrospectionResultAssembler;
 import org.mitre.openid.connect.config.ConfigurationPropertiesBean;
 import org.mitre.openid.connect.model.UserInfo;
@@ -31,26 +31,24 @@ public class PerunIntrospectionResultAssembler extends DefaultIntrospectionResul
 	private ScopeClaimTranslationService translator;
 
 	@Override
-	public Map<String, Object> assembleFrom(OAuth2AccessTokenEntity accessToken, UserInfo userInfo, Set<String> authScopes) {
+	public Map<String, Object> assembleFrom(OAuth2AccessTokenEntity accessToken, UserInfo userInfo, Set<String> resourceServerScopes) {
 		log.info("adding claims at Introspection endpoint for client {}({}) and user {}({})",
 				accessToken.getClient().getClientId(), accessToken.getClient().getClientName(), userInfo.getSub(), userInfo.getName());
-		Map<String, Object> map = super.assembleFrom(accessToken, userInfo, authScopes);
-		addDataToResponse(map, userInfo, authScopes);
+		Map<String, Object> map = super.assembleFrom(accessToken, userInfo, resourceServerScopes);
+		Set<String> accessTokenScopes = accessToken.getScope();
+		Set<String> scopes = Sets.intersection(resourceServerScopes, accessTokenScopes);
+		log.debug("resource server scopes: {}", resourceServerScopes);
+		log.debug("access token scopes   : {}", accessTokenScopes);
+		log.debug("common scopes         : {}", scopes);
+		addDataToResponse(map, userInfo, scopes);
 		return map;
 	}
 
-	@Override
-	public Map<String, Object> assembleFrom(OAuth2RefreshTokenEntity refreshToken, UserInfo userInfo, Set<String> authScopes) {
-		Map<String, Object> map = super.assembleFrom(refreshToken, userInfo, authScopes);
-		addDataToResponse(map, userInfo, authScopes);
-		return map;
-	}
-
-	private void addDataToResponse(Map<String, Object> map, UserInfo userInfo, Set<String> authScopes) {
+	private void addDataToResponse(Map<String, Object> map, UserInfo userInfo, Set<String> scopes) {
 		log.debug("adding iss to introspection response {}", map);
 		map.put("iss", configBean.getIssuer());
 		log.debug("adding user claims");
-		Set<String> authorizedClaims = translator.getClaimsForScopeSet(authScopes);
+		Set<String> authorizedClaims = translator.getClaimsForScopeSet(scopes);
 		for (Map.Entry<String, JsonElement> claim : userInfo.toJson().entrySet()) {
 			if (authorizedClaims.contains(claim.getKey()) && claim.getValue() != null && !claim.getValue().isJsonNull()) {
 				log.debug("adding claim {} with value {}", claim.getKey(), claim.getValue());


### PR DESCRIPTION
The user claims released at Introspection Endpoint are now restricted by the intersection of 
- scopes in access token (consented by user) 
- scopes registered for the resource server making the request to Introspection Endpoint