### PR TITLE
added framework for claim value modifiers

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunCustomClaimDefinition.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunCustomClaimDefinition.java
@@ -1,17 +1,18 @@
 package cz.muni.ics.oidc;
 
+import cz.muni.ics.oidc.claims.ClaimValueModifier;
+
 import java.util.regex.Pattern;
 
 /**
- * Keeps definitionof a custom user claim.
+ * Keeps definition of a custom user claim.
  * <ul>
  *     <li><b>scope</b> - which scope must be granted to include the claim</li>
  *     <li><b>claim</b> - name of the claim</li>
  *     <li><b>perunAttributeName</b> - id of Perun user attribute to obtain values from</li>
- *     <li><b>regex</b> - if defined, matching parts of each value will be replaced with replacement</li>
- *     <li><b>replacement</b> - string with ${g} or $g to replace matching groups</li>
+ *     <li><b>claimValueModifier</b> - instance of a class implementing {@link ClaimValueModifier}</li>
  * </ul>
- * @see java.util.regex.Matcher#replaceAll(String)
+ * @see ClaimValueModifier
  * @author Martin Kuba makub@ics.muni.cz
  */
 public class PerunCustomClaimDefinition {
@@ -19,15 +20,13 @@ public class PerunCustomClaimDefinition {
 	private String scope;
 	private String claim;
 	private String perunAttributeName;
-	private Pattern regex;
-	private String replacement;
+	private ClaimValueModifier claimValueModifier;
 
-	public PerunCustomClaimDefinition(String scope, String claim, String perunAttributeName,Pattern regex,String replacement) {
+	PerunCustomClaimDefinition(String scope, String claim, String perunAttributeName, ClaimValueModifier claimValueModifier) {
 		this.scope = scope;
 		this.claim = claim;
 		this.perunAttributeName = perunAttributeName;
-		this.regex = regex;
-		this.replacement = replacement;
+		this.claimValueModifier = claimValueModifier;
 	}
 
 	public String getScope() {
@@ -38,17 +37,12 @@ public class PerunCustomClaimDefinition {
 		return claim;
 	}
 
-	public String getPerunAttributeName() {
+	String getPerunAttributeName() {
 		return perunAttributeName;
 	}
 
-	public Pattern getRegex() {
-		return regex;
+	public ClaimValueModifier getClaimValueModifier() {
+		return claimValueModifier;
 	}
-
-	public String getReplacement() {
-		return replacement;
-	}
-
 
 }

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunScopeClaimTranslationService.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunScopeClaimTranslationService.java
@@ -27,9 +27,6 @@ public class PerunScopeClaimTranslationService implements ScopeClaimTranslationS
 	public void setPerunUserInfoRepository(PerunUserInfoRepository perunUserInfoRepository) {
 		for(PerunCustomClaimDefinition pccd : perunUserInfoRepository.getCustomClaims()) {
 			log.info("adding custom claim \"{}\" in scope \"{}\" ",pccd.getClaim(),pccd.getScope());
-			if(pccd.getRegex() != null) {
-				log.info("claim transformation: find={} replace={}",pccd.getRegex().pattern(),pccd.getReplacement());
-			}
 			scopesToClaims.put(pccd.getScope(),pccd.getClaim());
 		}
 	}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/AppendModifier.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/AppendModifier.java
@@ -1,0 +1,27 @@
+package cz.muni.ics.oidc.claims;
+
+/**
+ * Just appends a String.
+ *
+ * @author Martin Kuba makub@ics.muni.cz
+ */
+@SuppressWarnings("unused")
+public class AppendModifier extends ClaimValueModifier {
+
+	private String appendText;
+
+	public AppendModifier(ClaimValueModifierInitContext ctx) {
+		super(ctx);
+		appendText = ctx.getProperties().getProperty(ctx.getPropertyPrefix() + ".append", "");
+	}
+
+	@Override
+	public String modify(String value) {
+		return value + appendText;
+	}
+
+	@Override
+	public String toString() {
+		return "AppendModifier appending "+appendText;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/ClaimValueModifier.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/ClaimValueModifier.java
@@ -1,0 +1,20 @@
+package cz.muni.ics.oidc.claims;
+
+/**
+ * Interface for all code that needs to modify claim values .
+ *
+ * @author Martin Kuba makub@ics.muni.cz
+ */
+public abstract class ClaimValueModifier {
+
+	@SuppressWarnings("WeakerAccess")
+	public ClaimValueModifier(ClaimValueModifierInitContext ctx) {
+	}
+
+	public abstract String modify(String value);
+
+	@Override
+	public String toString() {
+		return this.getClass().getName();
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/ClaimValueModifierInitContext.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/ClaimValueModifierInitContext.java
@@ -1,0 +1,27 @@
+package cz.muni.ics.oidc.claims;
+
+import java.util.Properties;
+
+/**
+ * Context for initializing ClaimValueModifiers.
+ *
+ * @author Martin Kuba makub@ics.muni.cz
+ */
+public class ClaimValueModifierInitContext {
+
+	private final String propertyPrefix;
+	private final Properties properties;
+
+	public ClaimValueModifierInitContext(String propertyPrefix, Properties properties) {
+		this.propertyPrefix = propertyPrefix;
+		this.properties = properties;
+	}
+
+	public String getPropertyPrefix() {
+		return propertyPrefix;
+	}
+
+	public Properties getProperties() {
+		return properties;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/GroupNamesAARCFormatModifier.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/GroupNamesAARCFormatModifier.java
@@ -1,0 +1,32 @@
+package cz.muni.ics.oidc.claims;
+
+import com.google.common.net.UrlEscapers;
+
+/**
+ * Converts groupName values to AARC format.
+ *
+ * @author Martin Kuba makub@ics.muni.cz
+ */
+@SuppressWarnings("unused")
+public class GroupNamesAARCFormatModifier extends ClaimValueModifier {
+
+	private String prefix;
+	private String authority;
+
+	public GroupNamesAARCFormatModifier(ClaimValueModifierInitContext ctx) {
+		super(ctx);
+		prefix = ctx.getProperties().getProperty(ctx.getPropertyPrefix() + ".prefix", "urn:geant:cesnet.cz:group:");
+		authority = ctx.getProperties().getProperty(ctx.getPropertyPrefix() + ".authority", "perun.cesnet.cz");
+	}
+
+	@Override
+	public String modify(String value) {
+		return prefix + UrlEscapers.urlPathSegmentEscaper().escape(value)+ "#" + authority;
+	}
+
+
+	@Override
+	public String toString() {
+		return "GroupNamesAARCFormatModifier to " + prefix + "<GROUP>#" + authority;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/RegexReplaceModifier.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/claims/RegexReplaceModifier.java
@@ -1,0 +1,32 @@
+package cz.muni.ics.oidc.claims;
+
+import java.util.regex.Pattern;
+
+/**
+ * Replaces parts matched by regex with string using backreferences to groups.
+ *
+ * @see java.util.regex.Matcher#replaceAll(String)
+ * @author Martin Kuba makub@ics.muni.cz
+ */
+@SuppressWarnings("unused")
+public class RegexReplaceModifier extends ClaimValueModifier {
+
+	private Pattern regex;
+	private String replacement;
+
+	public RegexReplaceModifier(ClaimValueModifierInitContext ctx) {
+		super(ctx);
+		regex = Pattern.compile(ctx.getProperties().getProperty(ctx.getPropertyPrefix() + ".find", ""));
+		replacement = ctx.getProperties().getProperty(ctx.getPropertyPrefix() + ".replace", "");
+	}
+
+	@Override
+	public String modify(String value) {
+		return regex.matcher(value).replaceAll(replacement);
+	}
+
+	@Override
+	public String toString() {
+		return "RegexReplaceModifier replacing" + regex.pattern() + " with " + replacement;
+	}
+}

--- a/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
+++ b/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
@@ -12,8 +12,8 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
 		">
 
-	<context:property-placeholder properties-ref="coreProperties" ignore-unresolvable="false"/>
-	<context:component-scan annotation-config="true" base-package="cz.muni.ics.oidc"/>
+	<context:property-placeholder properties-ref="coreProperties"/>
+	<context:component-scan base-package="cz.muni.ics.oidc"/>
 
 	<!-- default config values, override in file /etc/perun/perun-mitreid.properties -->
 	<bean id="defaultCoreProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
@@ -33,8 +33,6 @@
 				<prop key="jwk">file:///etc/perun/perun-oidc-keystore.jwks</prop>
 				<prop key="admins">3197,59835</prop>
 				<prop key="attribute.openid.sub">urn:perun:user:attribute-def:core:id</prop>
-				<prop key="attribute.openid.sub.find">^(.*)$</prop>
-				<prop key="attribute.openid.sub.replace">$1</prop>
 				<prop key="attribute.profile.preferred_username">urn:perun:user:attribute-def:def:login-namespace:einfra</prop>
 				<prop key="attribute.profile.zoneinfo">urn:perun:user:attribute-def:def:timezone</prop>
 				<prop key="attribute.profile.locale">urn:perun:user:attribute-def:def:preferredLanguage</prop>
@@ -67,8 +65,6 @@
 	<bean id="userInfoRepository" primary="true" class="cz.muni.ics.oidc.PerunUserInfoRepository">
 		<property name="perunConnector" ref="perunConnector"/>
 		<property name="subAttribute" value="${attribute.openid.sub}"/>
-		<property name="subAttributeFind" value="${attribute.openid.sub.find}"/>
-		<property name="subAttributeReplacement" value="${attribute.openid.sub.replace}"/>
 		<property name="preferredUsernameAttribute" value="${attribute.profile.preferred_username}"/>
 		<property name="emailAttribute" value="${attribute.email.email}"/>
 		<property name="addressAttribute" value="${attribute.address.address.formatted}"/>
@@ -98,6 +94,7 @@
 	</bean>
 	<!-- authentication -->
 
+	<!--suppress SpringXmlModelInspection -->
 	<security:http auto-config="false" use-expressions="true" entry-point-ref="http403EntryPoint"
 	               authentication-manager-ref="authenticationManager">
 		<security:intercept-url pattern="/authorize" access="hasRole('ROLE_USER')"/>


### PR DESCRIPTION
Custom claims and the "sub" claim now can have modifiers, which are specified in the /etc/perun/perun-mitreid.properties file using properties "attribute.openid.sub.modifierClass" or "custom.claim.&lt;claim>.modifierClass". A modifier is a class that must extend the abstract class cz.muni.ics.oidc.claims.ClaimValueModifier, and can read configuration properties during its initialization.

Three modifiers are provided: AppendModifier, RegexReplaceModifier and GroupNamesAARCFormatModifier.

The AppendModifier is intended for appending domain to the "sub" claim. The GroupNamesAARCFormatModifier is intended for converting the groupNames claim into AARC format.