### PR TITLE
rebased on MITREid 1.3.3-SNAPSHOT

### DIFF
--- a/oidc-idp/src/main/resources/logback.xml
+++ b/oidc-idp/src/main/resources/logback.xml
@@ -38,10 +38,10 @@
 	<logger name="com.zaxxer.hikari" level="warn"/>
 	<logger name="cz.muni.ics.oidc" level="info"/>
 	<logger name="cz.muni.ics.oidc.PerunConnectorRpc" level="info"/>
-	<logger name="cz.muni.ics.oidc.PerunIntrospectionResultAssembler" level="debug"/>
+	<logger name="cz.muni.ics.oidc.PerunIntrospectionResultAssembler" level="info"/>
 	<logger name="cz.muni.ics.oidc.PerunUserInfo" level="info"/>
 	<logger name="cz.muni.ics.oidc.PerunUserInfoRepository" level="info"/>
 	<logger name="cz.muni.ics.oidc.PerunTokenEnhancer" level="debug"/>
-	<logger name="cz.muni.ics.oidc.elixir.DatasetPermissionsAccessTokenModifier" level="debug"/>
+	<logger name="cz.muni.ics.oidc.elixir.DatasetPermissionsAccessTokenModifier" level="info"/>
 
 </configuration>

--- a/oidc-idp/src/main/webapp/WEB-INF/tags/copyright.tag
+++ b/oidc-idp/src/main/webapp/WEB-INF/tags/copyright.tag
@@ -6,6 +6,7 @@
 <%
     PerunOidcConfig perunOidcConfig = WebApplicationContextUtils.getWebApplicationContext(application).getBean("perunOidcConfig", PerunOidcConfig.class);
 %>
-Powered by <a href="https://github.com/mitreid-connect/">MITREid Connect <span class="label"><%=perunOidcConfig.getMitreidVersion()%></span></a>,
-<a href="https://github.com/CESNET/perun-mitreid">Perun OIDC</a> <span class="label"><%=perunOidcConfig.getPerunOIDCVersion()%></span>
+Powered by
+<a href="https://github.com/CESNET/perun-mitreid">Perun MITREid</a> <span class="label"><%=perunOidcConfig.getPerunOIDCVersion()%></span>
+(modified <a href="https://github.com/mitreid-connect/">MITREid Connect <span class="label"><%=perunOidcConfig.getMitreidVersion()%></span></a>)
 <span class="pull-right">&copy; 2017 The MIT Internet Trust Consortium.</span>.

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	</modules>
 
 	<properties>
-		<mitreid-version>1.3.2</mitreid-version>
+		<mitreid-version>1.3.3-SNAPSHOT</mitreid-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java-version>8</java-version>
 		<maven.compiler.source>${java-version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,15 @@
 	<version>1.13-SNAPSHOT</version>
 	<name>Perun OpenID Connect Provider</name>
 
-   <developers>
-        <developer>
-            <name>Martin Kuba</name>
-            <email>makub@ics.muni.cz</email>
-            <url>http://www.muni.cz/people/3988</url>
-            <organization>ÚVT MU</organization>
-        </developer>
-    </developers>
- 
+	<developers>
+		<developer>
+			<name>Martin Kuba</name>
+			<email>makub@ics.muni.cz</email>
+			<url>http://www.muni.cz/people/3988</url>
+			<organization>ÚVT MU</organization>
+		</developer>
+	</developers>
+
 	<modules>
 		<module>oidc-idp</module>
 	</modules>
@@ -28,6 +28,22 @@
 		<maven.compiler.source>${java-version}</maven.compiler.source>
 		<maven.compiler.target>${java-version}</maven.compiler.target>
 	</properties>
+
+	<!-- needed for Travis Continuous Integration to succeed, because MITREid 1.3.3-SNAPSHOT is not released -->
+	<repositories>
+		<repository>
+			<id>acrab.ics.muni.cz</id>
+			<name>Maven Repository</name>
+			<url>https://acrab.ics.muni.cz/~makub/m2repo/</url>
+			<layout>default</layout>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
+	</repositories>
 
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Rebased on MITREid 1.3.3-SNAPSHOT to support Device code flow. Also set all logging levels to INFO, and changed the order of Perun MITREid a MITREid Connect versions reported in GUI footer.