### PR TITLE
Model objects are used as return type of methods in PerunConnector

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/Mapper.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/Mapper.java
@@ -1,0 +1,102 @@
+package cz.muni.ics.oidc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import cz.muni.ics.oidc.models.Facility;
+import cz.muni.ics.oidc.models.Group;
+import cz.muni.ics.oidc.models.Member;
+import cz.muni.ics.oidc.models.Resource;
+import cz.muni.ics.oidc.models.RichUser;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class is mapping JsonNodes to object models.
+ *
+ * @author Peter Jancus jancus@ics.muni.cz
+ */
+public class Mapper {
+
+	/**
+	 * Maps JsonNode to Facility model
+	 * @param jsonNode facility in Json format to be mapped
+	 * @return Facility mapped from JsonNode
+	 */
+	public static Facility mapFacility(JsonNode jsonNode) {
+		Long id = jsonNode.get("id").asLong();
+		String name = jsonNode.get("name").asText();
+		String description = jsonNode.get("description").asText();
+
+		return new Facility(id, name, description);
+	}
+
+	/**
+	 * Maps JsonNode to Group model
+	 * @param jsonNode group in Json format to be mapped
+	 * @return Group mapped from JsonNode
+	 */
+	public static Group mapGroup(JsonNode jsonNode) {
+		Long id = jsonNode.get("id").asLong();
+		Long parentGroupId = jsonNode.get("parentGroupId").asLong();
+		String name = jsonNode.get("name").asText();
+		String description = jsonNode.get("description").asText();
+		String shortName = jsonNode.get("shortName").asText();
+
+		return new Group(id, parentGroupId, name, description, shortName);
+	}
+
+	/**
+	 * Maps JsonNode to Member model
+	 * @param jsonNode member in Json format to be mapped
+	 * @return Member mapped from JsonNode
+	 */
+	public static Member mapMember(JsonNode jsonNode) {
+		Long id = jsonNode.get("id").asLong();
+		Long userId = jsonNode.get("userId").asLong();
+		Long voId = jsonNode.get("voId").asLong();
+		String status = jsonNode.get("status").asText();
+
+		return new Member(id, userId, voId, status);
+	}
+
+	/**
+	 * Maps JsonNode to Resource model
+	 * @param jsonNode resource in Json format to be mapped
+	 * @return Resource mapped from JsonNode
+	 */
+	public static Resource mapResource(JsonNode jsonNode) {
+		Long id = jsonNode.get("id").asLong();
+		Long voId = jsonNode.get("voId").asLong();
+		String name = jsonNode.get("name").asText();
+		String description = jsonNode.get("description").asText();
+
+		return new Resource(id, voId, name, description);
+	}
+
+	/**
+	 * Mapps JsonNode to RichUser model
+	 * @param jsonNode rich user in Json format to be mapped
+	 * @return RichUser mapped from JsonNode
+	 */
+	public static RichUser mapRichUser (JsonNode jsonNode) {
+		Map<String, JsonNode> map = new HashMap<>();
+
+		Long id = jsonNode.get("id").asLong();
+		String firstName = jsonNode.get("firstName").asText();
+		String lastName = jsonNode.get("lastName").asText();
+		String middleName = jsonNode.get("middleName").asText();
+		RichUser richUser = new RichUser(id, firstName, lastName, middleName);
+
+		JsonNode attributesNode = jsonNode.get("userAttributes");
+
+		for (int i = 0; i < attributesNode.size(); i++) {
+			String friendlyName = attributesNode.get(i).get("friendlyName").asText();
+			String namespace = attributesNode.get(i).get("namespace").asText();
+			JsonNode valueNode = attributesNode.get(i).get("value");
+			map.put(namespace + ":" + friendlyName, valueNode);
+		}
+		richUser.setAttributes(map);
+		return richUser;
+	}
+
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunConnector.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunConnector.java
@@ -1,12 +1,20 @@
 package cz.muni.ics.oidc;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import cz.muni.ics.oidc.models.Facility;
+import cz.muni.ics.oidc.models.Group;
+import cz.muni.ics.oidc.models.Member;
+import cz.muni.ics.oidc.models.Resource;
+import cz.muni.ics.oidc.models.RichUser;
+
+import java.util.List;
 
 /**
  * Connects to Perun and obtains information.
  *
  * @author Martin Kuba makub@ics.muni.czc
  * @author Dominik František Bučík bucik@ics.muni.cz
+ * @author Peter Jancus jancus@ics.muni.cz
  */
 public interface PerunConnector {
 
@@ -20,44 +28,44 @@ public interface PerunConnector {
 	/**
 	 * Fetch user identified by userId from Perun
 	 * @param userId identifier of the user
-	 * @return JsonNode with attributes of found user
+	 * @return RichUser with attributes of found user
 	 */
-	JsonNode getUserAttributes(Long userId);
+	RichUser getUserAttributes(Long userId);
 
 	/**
 	 * Fetch OIDC facility from Perun
 	 * @param clientId value for attribute OIDCClientID
-	 * @return JsonNode with attributes of found facility
+	 * @return List of facilities if it has found at least one, empty list otherwise
 	 */
-	JsonNode getFacilitiesByClientId(String clientId);
+	List<Facility> getFacilitiesByClientId(String clientId);
 
 	/**
 	 * Fetch resources assigned to facility specified by id
 	 * @param facilityId id of facility
-	 * @return JsonNode with assigned resources
+	 * @return List of assigned resources if it has found at least one, empty list otherwise
 	 */
-	JsonNode getAssignedResourcesForFacility(String facilityId);
+	List<Resource> getAssignedResourcesForFacility(Long facilityId);
 
 	/**
 	 * Fetch all groups associated with resource and member
 	 * @param resourceId id of resource
 	 * @param memberId id of member
-	 * @return JsonNode with groups associated both with resource and member
+	 * @return List of groups associated both with resource and member if it has found at least one, empty list otherwise
 	 */
-	JsonNode getAssignedGroups(String resourceId, String memberId);
+	List<Group> getAssignedGroups(Long resourceId, Long memberId);
 
 	/**
 	 * Fetch members of user specified by his/her id
 	 * @param userId id of user
-	 * @return JsonNode with user members
+	 * @return List of user members if it has found at least one, empty list otherwise
 	 */
-	JsonNode getMembersByUser(String userId);
+	List<Member> getMembersByUser(String userId);
 
 	/**
 	 * Ask Perun if membership of user in groups allowed to access resource should be checked.
 	 * @param facilityId id of facility to be accessed
 	 * @return TRUE if check should be done, FALSE otherwise
 	 */
-	boolean isAllowedGroupCheckForFacility(String facilityId);
+	boolean isAllowedGroupCheckForFacility(Long facilityId);
 
 }

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunUserInfoRepository.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/PerunUserInfoRepository.java
@@ -9,6 +9,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import cz.muni.ics.oidc.claims.ClaimValueModifier;
 import cz.muni.ics.oidc.claims.ClaimValueModifierInitContext;
+import cz.muni.ics.oidc.models.RichUser;
 import org.mitre.openid.connect.model.Address;
 import org.mitre.openid.connect.model.DefaultAddress;
 import org.mitre.openid.connect.model.UserInfo;
@@ -31,6 +32,7 @@ import java.util.concurrent.TimeUnit;
  * Provides data about a user.
  *
  * @author Martin Kuba makub@ics.muni.cz
+ * @author Peter Jancus jancus@ics.muni.cz
  */
 public class PerunUserInfoRepository implements UserInfoRepository {
 
@@ -189,11 +191,11 @@ public class PerunUserInfoRepository implements UserInfoRepository {
 		public UserInfo load(String username) {
 			log.trace("load({})", username);
 			PerunUserInfo ui = new PerunUserInfo();
-			JsonNode result = perunConnector.getUserAttributes(Long.parseLong(username));
+			RichUser richUser = perunConnector.getUserAttributes(Long.parseLong(username));
 			//process
-			RichUser richUser = new RichUser(result);
 
-			String sub = richUser.get(subAttribute);
+
+			String sub = richUser.getAttributeValue(subAttribute);
 			if (sub == null) {
 				throw new RuntimeException("cannot get sub from attribute " + subAttribute + " for username " + username);
 			}
@@ -205,26 +207,26 @@ public class PerunUserInfoRepository implements UserInfoRepository {
 			ui.setId(Long.parseLong(username));
 			ui.setSub(sub); // Subject - Identifier for the End-User at the Issuer.
 
-			ui.setPreferredUsername(richUser.get(preferredUsernameAttribute)); // Shorthand name by which the End-User wishes to be referred to at the RP
-			ui.setGivenName(richUser.get("urn:perun:user:attribute-def:core:firstName")); //  Given name(s) or first name(s) of the End-User
-			ui.setFamilyName(richUser.get("urn:perun:user:attribute-def:core:lastName")); // Surname(s) or last name(s) of the End-User
-			ui.setMiddleName(richUser.get("urn:perun:user:attribute-def:core:middleName")); //  Middle name(s) of the End-User
-			ui.setName(richUser.get("urn:perun:user:attribute-def:core:displayName")); // End-User's full name
+			ui.setPreferredUsername(richUser.getAttributeValue(preferredUsernameAttribute)); // Shorthand name by which the End-User wishes to be referred to at the RP
+			ui.setGivenName(richUser.getAttributeValue("urn:perun:user:attribute-def:core:firstName")); //  Given name(s) or first name(s) of the End-User
+			ui.setFamilyName(richUser.getAttributeValue("urn:perun:user:attribute-def:core:lastName")); // Surname(s) or last name(s) of the End-User
+			ui.setMiddleName(richUser.getAttributeValue("urn:perun:user:attribute-def:core:middleName")); //  Middle name(s) of the End-User
+			ui.setName(richUser.getAttributeValue("urn:perun:user:attribute-def:core:displayName")); // End-User's full name
 			//ui.setNickname(); // Casual name of the End-User
 			//ui.setProfile(); //  URL of the End-User's profile page.
 			//ui.setPicture(); // URL of the End-User's profile picture.
 			//ui.setWebsite(); // URL of the End-User's Web page or blog.
-			ui.setEmail(richUser.get(emailAttribute)); // End-User's preferred e-mail address.
+			ui.setEmail(richUser.getAttributeValue(emailAttribute)); // End-User's preferred e-mail address.
 			//ui.setEmailVerified(true); // True if the End-User's e-mail address has been verified
 			//ui.setGender("male"); // End-User's gender. Values defined by this specification are female and male.
 			//ui.setBirthdate("1975-01-01");//End-User's birthday, represented as an ISO 8601:2004 [ISO8601‑2004] YYYY-MM-DD format.
-			ui.setZoneinfo(richUser.get(zoneinfoAttribute));//String from zoneinfo [zoneinfo] time zone database, For example, Europe/Paris
-			ui.setLocale(richUser.get(localeAttribute)); //  For example, en-US or fr-CA.
-			ui.setPhoneNumber(richUser.get(phoneAttribute)); //[E.164] is RECOMMENDED as the format, for example, +1 (425) 555-121
+			ui.setZoneinfo(richUser.getAttributeValue(zoneinfoAttribute));//String from zoneinfo [zoneinfo] time zone database, For example, Europe/Paris
+			ui.setLocale(richUser.getAttributeValue(localeAttribute)); //  For example, en-US or fr-CA.
+			ui.setPhoneNumber(richUser.getAttributeValue(phoneAttribute)); //[E.164] is RECOMMENDED as the format, for example, +1 (425) 555-121
 			//ui.setPhoneNumberVerified(true); // True if the End-User's phone number has been verified
 			//ui.setUpdatedTime(Long.toString(System.currentTimeMillis()/1000L));// value is a JSON number representing the number of seconds from 1970-01-01T0:0:0Z as measured in UTC until the date/time
 			Address address = new DefaultAddress();
-			address.setFormatted(richUser.get(addressAttribute));
+			address.setFormatted(richUser.getAttributeValue(addressAttribute));
 			//address.setStreetAddress("Šumavská 15");
 			//address.setLocality("Brno");
 			//address.setPostalCode("61200");
@@ -261,30 +263,4 @@ public class PerunUserInfoRepository implements UserInfoRepository {
 		}
 	};
 
-
-
-	private static class RichUser {
-		Map<String, JsonNode> map = new HashMap<>();
-
-		RichUser(JsonNode jsonNode) {
-			log.trace("parsing user attributes");
-			for (JsonNode ua : jsonNode.path("userAttributes")) {
-				String attributeName = ua.path("namespace").asText() + ":" + ua.path("friendlyName").asText();
-				JsonNode value = ua.path("value");
-				log.trace("got user attribute {} = {}", attributeName, value);
-				map.put(attributeName, value);
-			}
-		}
-
-		JsonNode getJson(String s) {
-			return map.get(s);
-		}
-
-		String get(String s) {
-			JsonNode jsonNode = map.get(s);
-			if (jsonNode == null) return null;
-			if (jsonNode.isNull()) return null;
-			return jsonNode.asText();
-		}
-	}
 }

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Facility.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Facility.java
@@ -1,0 +1,34 @@
+package cz.muni.ics.oidc.models;
+
+/**
+ * Facility object model.
+ *
+ * @author Peter Jancus jancus@ics.muni.cz
+ */
+public class Facility extends Model {
+
+	private String name;
+	private String description;
+
+	public Facility(Long id, String name, String description) {
+		super(id);
+		this.name = name;
+		this.description = description;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Group.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Group.java
@@ -1,0 +1,54 @@
+package cz.muni.ics.oidc.models;
+
+/**
+ * Group object model.
+ *
+ * @author Peter Jancus jancus@ics.muni.cz
+ */
+public class Group extends Model {
+
+	private Long parentGroupId;
+	private String name;
+	private String description;
+	private String shortName;
+
+	public Group(Long id, Long parentGroupId, String name, String description, String shortName) {
+		super(id);
+		this.parentGroupId = parentGroupId;
+		this.name = name;
+		this.description = description;
+		this.shortName = shortName;
+	}
+
+	public Long getParentGroupId() {
+		return parentGroupId;
+	}
+
+	public void setParentGroupId(Long parentGroupId) {
+		this.parentGroupId = parentGroupId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getShortName() {
+		return shortName;
+	}
+
+	public void setShortName(String shortName) {
+		this.shortName = shortName;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Member.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Member.java
@@ -1,0 +1,44 @@
+package cz.muni.ics.oidc.models;
+
+/**
+ * Member object model.
+ *
+ * @author Peter Jancus jancus@ics.muni.cz
+ */
+public class Member extends Model {
+
+	private Long userId;
+	private Long voId;
+	private String status;
+
+	public Member(Long id, Long userId, Long voId, String status) {
+		super(id);
+		this.userId = userId;
+		this.voId = voId;
+		this.status = status;
+	}
+
+	public Long getUserId() {
+		return userId;
+	}
+
+	public void setUserId(Long userId) {
+		this.userId = userId;
+	}
+
+	public Long getVoId() {
+		return voId;
+	}
+
+	public void setVoId(Long voId) {
+		this.voId = voId;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Model.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Model.java
@@ -1,0 +1,26 @@
+package cz.muni.ics.oidc.models;
+
+/**
+ * Basic model object, which is extended by another specific models with specific variables.
+ *
+ * Created as replacement of JsonNode for PerunConnector methods return types.
+ */
+public abstract class Model {
+
+	private Long id;
+
+	public Model() {
+	}
+
+	public Model(Long id) {
+		this.id = id;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Resource.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/models/Resource.java
@@ -1,0 +1,44 @@
+package cz.muni.ics.oidc.models;
+
+/**
+ * Resource object model.
+ *
+ * @author Peter Jancus jancus@ics.muni.cz
+ */
+public class Resource extends Model {
+
+	private Long voId;
+	private String name;
+	private String description;
+
+	public Resource(Long id, Long voId, String name, String description) {
+		super(id);
+		this.voId = voId;
+		this.name = name;
+		this.description = description;
+	}
+
+	public Long getVoId() {
+		return voId;
+	}
+
+	public void setVoId(Long voId) {
+		this.voId = voId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/models/RichUser.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/models/RichUser.java
@@ -1,0 +1,71 @@
+package cz.muni.ics.oidc.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * RichUser object model.
+ *
+ * @author Peter Jancus jancus@ics.muni.cz
+ */
+public class RichUser extends Model {
+
+	private String firstName;
+	private String lastName;
+	private String middleName;
+	private Map<String, JsonNode> attributes = new LinkedHashMap<>();
+
+	public RichUser(Long id, String firstName, String lastName, String middleName) {
+		super(id);
+		this.firstName = firstName;
+		this.lastName = lastName;
+		this.middleName = middleName;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public String getMiddleName() {
+		return middleName;
+	}
+
+	public void setMiddleName(String middleName) {
+		this.middleName = middleName;
+	}
+
+	public Map<String, JsonNode> getAttributes() {
+		return attributes;
+	}
+
+	public void setAttributes(Map<String, JsonNode> attributes) {
+		this.attributes = attributes;
+	}
+
+	public String getAttributeValue(String attrName) {
+		if (attributes.containsKey(attrName) && attributes.get(attrName) != null) {
+			return attributes.get(attrName).asText();
+		} else {
+			return null;
+		}
+
+	}
+
+	public JsonNode getJson(String attrName) {
+		return attributes.get(attrName);
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/models/RichUser.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/models/RichUser.java
@@ -57,12 +57,8 @@ public class RichUser extends Model {
 	}
 
 	public String getAttributeValue(String attrName) {
-		if (attributes.containsKey(attrName) && attributes.get(attrName) != null) {
-			return attributes.get(attrName).asText();
-		} else {
-			return null;
-		}
-
+		JsonNode jsonNode = attributes.get(attrName);
+		return (jsonNode == null) || jsonNode.isNull() ? null : jsonNode.asText();
 	}
 
 	public JsonNode getJson(String attrName) {


### PR DESCRIPTION
- Whole project updated, so connector methods return specific model objects instead of JsonNode objects.
- Many object models created, each extends abstract class Model, which has just 1 variable (id) and each class is specific with own variables due to its needs.
- One simple Mapper class created, which maps JsonNode to objects.
- Documentation updated.
