### PR TITLE
added configurable names for attributes with idp name and id to statistics filter

### DIFF
--- a/oidc-idp/src/main/resources/logback.xml
+++ b/oidc-idp/src/main/resources/logback.xml
@@ -26,7 +26,7 @@
 		<suffixPattern>%d %-5level %logger{40} - %msg%n</suffixPattern>
 	</appender>
 
-	<root level="debug">
+	<root level="info">
 		<appender-ref ref="SYSLOG"/>
 	</root>
 
@@ -40,7 +40,8 @@
 	<!--<logger name="org.springframework.http.client" level="debug"/>-->
 	<!--<logger name="org.springframework.web.client" level="debug"/>-->
 	<logger name="com.zaxxer.hikari" level="warn"/>
-	<logger name="org.mitre" level="debug"/>
-	<logger name="cz.muni.ics.oidc" level="debug"/>
+	<logger name="org.mitre" level="info"/>
+	<logger name="cz.muni.ics.oidc" level="info"/>
+	<logger name="cz.muni.ics.oidc.filters.ProxyStatisticsFilter" level="debug"/>
 
 </configuration>

--- a/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
+++ b/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
@@ -37,6 +37,8 @@
 				<prop key="stats.tableName.identityProvidersMap">identityProvidersMap</prop>
 				<prop key="stats.tableName.serviceProviders">serviceProviders</prop>
 				<prop key="stats.tableName.serviceProvidersMap">serviceProvidersMap</prop>
+				<prop key="stats.idp.name.attribute">sourceIdPName</prop>
+				<prop key="stats.idp.entityID.attribute">sourceIdPEntityID</prop>
 				<prop key="jwk">file:///etc/perun/perun-oidc-keystore.jwks</prop>
 				<prop key="admins">3197,59835</prop>
 				<prop key="attribute.openid.sub">urn:perun:user:attribute-def:core:id</prop>
@@ -143,6 +145,8 @@
 		<property name="identityProvidersMapTableName" value="${stats.tableName.identityProvidersMap}"/>
 		<property name="serviceProvidersTableName" value="${stats.tableName.serviceProviders}"/>
 		<property name="serviceProvidersMapTableName" value="${stats.tableName.serviceProvidersMap}"/>
+		<property name="idpNameAttributeName" value="${stats.idp.name.attribute}"/>
+		<property name="idpEntityIdAttributeName" value="${stats.idp.entityID.attribute}"/>
 	</bean>
 
 	<!-- decides who is admin -->


### PR DESCRIPTION
The names for request attributes containing IdP's nname and id were previously hardcoded, now they are configurable.