### PR TITLE
Added options for running multiple instances

### DIFF
--- a/oidc-idp/pom.xml
+++ b/oidc-idp/pom.xml
@@ -12,7 +12,26 @@
 	<artifactId>oidc-idp</artifactId>
 	<packaging>war</packaging>
 
+	<properties>
+		<config.location>/etc/perun/perun-mitreid.properties</config.location>
+		<log.to>FILE</log.to>
+		<log.contextName>oidc</log.contextName>
+		<log.facility>LOCAL7</log.facility>
+		<log.level>info</log.level>
+		<final.name>oidc</final.name>
+	</properties>
+
 	<build>
+		<finalName>${final.name}</finalName>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>logback.xml</include>
+				</includes>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -24,6 +43,15 @@
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.1.1</version>
 				<configuration>
+					<webResources>
+						<resource>
+							<filtering>true</filtering>
+							<directory>src/main/webapp</directory>
+							<includes>
+								<include>WEB-INF/user-context.xml</include>
+							</includes>
+						</resource>
+					</webResources>
 					<overlays>
 						<overlay>
 							<groupId>org.mitre</groupId>

--- a/oidc-idp/src/main/resources/logback.xml
+++ b/oidc-idp/src/main/resources/logback.xml
@@ -1,9 +1,9 @@
 <configuration packagingData="true" debug="false" scan="false" scanPeriod="30 seconds">
-	<contextName>oidc</contextName>
-	<!--
+	<contextName>${log.contextName}</contextName>
+
 	<if condition='isDefined("catalina.base")'>
 		<then>
-			<appender name="APP" class="ch.qos.logback.core.rolling.RollingFileAppender">
+			<appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 				<file>${catalina.base}/logs/${CONTEXT_NAME}.log</file>
 				<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 					<fileNamePattern>${catalina.base}/logs/${CONTEXT_NAME}.log.%d{yyyy-MM-dd}</fileNamePattern>
@@ -14,25 +14,24 @@
 			</appender>
 		</then>
 		<else>
-			<appender name="APP" class="ch.qos.logback.core.ConsoleAppender">
+			<appender name="FILE" class="ch.qos.logback.core.ConsoleAppender">
 				<encoder>
 					<pattern>%d [%thread] %-5level %logger{120} - %msg%n</pattern>
 				</encoder>
 			</appender>
 		</else>
 	</if>
-	<root level="info">
-		<appender-ref ref="APP"/>
-	</root>
-	-->
 	<appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
-		<facility>LOCAL7</facility>
-		<suffixPattern>%d %-5level %logger{40} - %msg%n</suffixPattern>
+		<!-- PASSED FROM POM.XML / MAVEN BUILD PROPS -->
+		<facility>${log.facility}</facility>
+		<throwableExcluded>true</throwableExcluded>
+		<suffixPattern>%cn : %-5level %logger{40} - %m%n%xException</suffixPattern>
 	</appender>
-	<root level="info">
-		<appender-ref ref="SYSLOG"/>
-	</root>
 
+	<root level="info">
+		<!-- PASSED FROM POM.XML / MAVEN BUILD PROPS -->
+		<appender-ref ref="${log.to}"/>
+	</root>
 
 	<!-- keep Spring quiet -->
 	<logger name="org.springframework" level="warn"/>
@@ -47,11 +46,8 @@
 	<!--<logger name="org.springframework.web.client" level="debug"/>-->
 	<logger name="com.zaxxer.hikari" level="warn"/>
 	<logger name="org.mitre" level="info"/>
-	<logger name="cz.muni.ics.oidc" level="info"/>
-	<logger name="cz.muni.ics.oidc.filters.ProxyStatisticsFilter" level="info"/>
-	<logger name="cz.muni.ics.oidc.PerunConnectorLdap" level="info"/>
-	<logger name="cz.muni.ics.oidc.PerunConnectorRpc" level="info"/>
-	<logger name="cz.muni.ics.oidc.controllers.PerunOAuthConfirmationController" level="info"/>
+	<!-- PASSED FROM POM.XML / MAVEN BUILD PROPS -->
+	<logger name="cz.muni.ics.oidc" level="${log.level}"/>
 
 
 </configuration>

--- a/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
+++ b/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
@@ -92,7 +92,8 @@
 		<property name="properties" ref="defaultCoreProperties"/>
 		<property name="locations">
 			<list>
-				<value>file:/etc/perun/perun-mitreid.properties</value>
+				<!-- PASSED FROM POM.XML / MAVEN BUILD PROPS -->
+				<value>file://${config.location}</value>
 			</list>
 		</property>
 		<property name="ignoreResourceNotFound" value="false"/>


### PR DESCRIPTION
When building via maven following options can be specified:
* Added ability to specify location of the conguration file -Dconfig.location=location [default: /etc/perun/perun-mitreid.properties]
* Added ability to specify logging style -Dlog.to=FILE|SYSLOG [default: FILE]
* Added ability to specify logging contextName -Dlog.contextName=contextName [default: oidc]
* Added ability to specify logging facility (syslog) -Dlog.facility=facility [default: LOCAL7]
* Added ability to specify logging level -Dlog.level=level [default: info]
* Added ability to specify final build name -Dfinal.name=name [default: oidc]