### PR TITLE
Added option to specify extSource name

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
@@ -31,6 +31,7 @@ public class PerunOidcConfig {
 	private boolean askPerunForIdpFiltersEnabled;
 	private String perunOIDCVersion;
 	private String mitreidVersion;
+	private String proxyExtSourceName;
 
 	@Autowired
 	private ServletContext servletContext;
@@ -111,6 +112,18 @@ public class PerunOidcConfig {
 		this.askPerunForIdpFiltersEnabled = askPerunForIdpFiltersEnabled;
 	}
 
+	public String getProxyExtSourceName() {
+		return proxyExtSourceName;
+	}
+
+	public void setProxyExtSourceName(String proxyExtSourceName) {
+		if (proxyExtSourceName == null || proxyExtSourceName.isEmpty()) {
+			this.proxyExtSourceName = null;
+		} else {
+			this.proxyExtSourceName = proxyExtSourceName;
+		}
+	}
+
 	@PostConstruct
 	public void postInit() {
 		log.info("Perun OIDC initialized");
@@ -123,8 +136,8 @@ public class PerunOidcConfig {
 		log.info("Registrar URL: {}", registrarUrl);
 		log.info("LOGIN URL: {}", loginUrl);
 		log.info("accessTokenClaimsModifier: {}", coreProperties.getProperty("accessTokenClaimsModifier"));
+		log.info("Proxy EXT_SOURCE name: {}", proxyExtSourceName);
 		log.info("MitreID version: {}", getMitreidVersion());
 		log.info("Perun OIDC version: {}", getPerunOIDCVersion());
 	}
-
 }

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthenticationFilter.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthenticationFilter.java
@@ -9,6 +9,7 @@ import cz.muni.ics.oidc.server.connectors.PerunConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 
 import javax.servlet.FilterChain;
@@ -117,7 +118,10 @@ public class PerunAuthenticationFilter extends AbstractPreAuthenticatedProcessin
 
 		PerunPrincipal perunPrincipal = extractPerunPrincipal(req);
 		if (perunPrincipal == null) {
-			String shibIdentityProvider = (String) req.getAttribute(SHIB_IDENTITY_PROVIDER);
+			String shibIdentityProvider = config.getProxyExtSourceName();
+			if (shibIdentityProvider == null) {
+				shibIdentityProvider = (String) req.getAttribute(SHIB_IDENTITY_PROVIDER);
+			}
 			String remoteUser = req.getRemoteUser();
 			throw new IllegalStateException("ExtSource name or userExtSourceLogin is null. " +
 					"extSourceName: " + shibIdentityProvider + ", " +
@@ -137,7 +141,10 @@ public class PerunAuthenticationFilter extends AbstractPreAuthenticatedProcessin
 		String extLogin = null;
 		String extSourceName = null;
 
-		String shibIdentityProvider = (String) req.getAttribute(SHIB_IDENTITY_PROVIDER);
+		String shibIdentityProvider = config.getProxyExtSourceName();
+		if (shibIdentityProvider == null) {
+			shibIdentityProvider = (String) req.getAttribute(SHIB_IDENTITY_PROVIDER);
+		}
 		String remoteUser = req.getRemoteUser();
 
 		if (isNotEmpty(shibIdentityProvider)) {

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthorizationFilter.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthorizationFilter.java
@@ -5,6 +5,7 @@ import cz.muni.ics.oidc.models.PerunAttribute;
 import cz.muni.ics.oidc.models.PerunUser;
 import cz.muni.ics.oidc.server.PerunPrincipal;
 import cz.muni.ics.oidc.server.configurations.FacilityAttrsConfig;
+import cz.muni.ics.oidc.server.configurations.PerunOidcConfig;
 import cz.muni.ics.oidc.server.connectors.PerunConnector;
 import cz.muni.ics.oidc.web.controllers.ControllerUtils;
 import cz.muni.ics.oidc.web.controllers.PerunUnapprovedController;
@@ -57,6 +58,9 @@ public class PerunAuthorizationFilter extends GenericFilterBean {
 	@Autowired
 	private FacilityAttrsConfig facilityAttrsConfig;
 
+	@Autowired
+	private PerunOidcConfig perunOidcConfig;
+
 	private static final String REQ_PATTERN = "/authorize";
 	private static final String SHIB_IDENTITY_PROVIDER = "Shib-Identity-Provider";
 	private RequestMatcher requestMatcher = new AntPathRequestMatcher(REQ_PATTERN);
@@ -86,7 +90,10 @@ public class PerunAuthorizationFilter extends GenericFilterBean {
 		}
 
 		Principal p = request.getUserPrincipal();
-		String shibIdentityProvider = (String) req.getAttribute(SHIB_IDENTITY_PROVIDER);
+		String shibIdentityProvider = perunOidcConfig.getProxyExtSourceName();
+		if (shibIdentityProvider == null) {
+			shibIdentityProvider = (String) req.getAttribute(SHIB_IDENTITY_PROVIDER);
+		}
 		PerunPrincipal principal = new PerunPrincipal(p.getName(), shibIdentityProvider);
 		PerunUser user = perunConnector.getPreauthenticatedUserId(principal);
 

--- a/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
+++ b/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
@@ -23,6 +23,7 @@
 				<prop key="logo.image.url">resources/images/perun_24px.png</prop>
 				<prop key="topbar.title">Perun OIDC</prop>
 				<prop key="proxy.login.url">https://login.cesnet.cz/Shibboleth.sso/Login</prop>
+				<prop key="proxy.extSource.name"/>
 				<prop key="perun.rpc.url">https://perun.elixir-czech.cz/krb/rpc</prop>
 				<prop key="perun.rpc.user">xxxxx</prop>
 				<prop key="perun.rpc.password">yyyyy</prop>
@@ -144,6 +145,7 @@
 		<property name="registrarUrl" value="${registrar.url}"/>
 		<property name="loginUrl" value="${proxy.login.url}"/>
 		<property name="askPerunForIdpFiltersEnabled" value="${idpFilters.askPerun.enabled}"/>
+		<property name="proxyExtSourceName" value="${proxy.extSource.name}"/>
 	</bean>
 
 	<bean id="facilityAttrsConfig" class="cz.muni.ics.oidc.server.configurations.FacilityAttrsConfig">


### PR DESCRIPTION
- When user logs in, MitreID tries to fetch user from Perun. We can now specify name of the ext source the request should use when fetching user by his extLogin and extSourceName
- When option left empty, extSourceName is fetched from request header Shib-Identity-Provider
- When option is set, request header Shib-Identity-Provider is ignored