### PR TITLE
implemented SAML logout

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
@@ -4,6 +4,9 @@ import org.mitre.openid.connect.config.ConfigurationPropertiesBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletContext;
@@ -27,7 +30,8 @@ public class PerunOidcConfig {
 	private String jdbcUrl;
 	private String theme;
 	private String registrarUrl;
-	private String loginUrl;
+	private String samlLoginURL;
+	private String samlLogoutURL;
 	private boolean askPerunForIdpFiltersEnabled;
 	private String perunOIDCVersion;
 	private String mitreidVersion;
@@ -96,13 +100,22 @@ public class PerunOidcConfig {
 		}
 	}
 
-	public void setLoginUrl(String loginUrl) {
-		this.loginUrl = loginUrl;
+	public void setSamlLoginURL(String samlLoginURL) {
+		this.samlLoginURL = samlLoginURL;
 	}
 
-	public String getLoginUrl() {
-		return loginUrl;
+	public String getSamlLoginURL() {
+		return samlLoginURL;
 	}
+
+	public void setSamlLogoutURL(String samlLogoutURL) {
+		this.samlLogoutURL = samlLogoutURL;
+	}
+
+	public String getSamlLogoutURL() {
+		return samlLogoutURL;
+	}
+
 
 	public boolean isAskPerunForIdpFiltersEnabled() {
 		return askPerunForIdpFiltersEnabled;
@@ -126,18 +139,40 @@ public class PerunOidcConfig {
 
 	@PostConstruct
 	public void postInit() {
-		log.info("Perun OIDC initialized");
-		log.info("Mitreid config URL: {}", configBean.getIssuer());
-		log.info("RPC URL: {}", rpcUrl);
-		log.info("JSON Web Keys: {}", jwk);
-		log.info("JDBC URL: {}", jdbcUrl);
-		log.info("LDAP: ldaps://{}/{}", coreProperties.getProperty("ldap.host"), coreProperties.getProperty("ldap.baseDN"));
-		log.info("THEME: {}", theme);
-		log.info("Registrar URL: {}", registrarUrl);
-		log.info("LOGIN URL: {}", loginUrl);
-		log.info("accessTokenClaimsModifier: {}", coreProperties.getProperty("accessTokenClaimsModifier"));
-		log.info("Proxy EXT_SOURCE name: {}", proxyExtSourceName);
-		log.info("MitreID version: {}", getMitreidVersion());
-		log.info("Perun OIDC version: {}", getPerunOIDCVersion());
+		//load URLs from properties if available or construct them from issuer URL
+		String loginURL = coreProperties.getProperty("proxy.login.url");
+		if (loginURL != null && !loginURL.trim().isEmpty()) {
+			samlLoginURL = loginURL.trim();
+		} else {
+			samlLoginURL = UriComponentsBuilder.fromHttpUrl(configBean.getIssuer()).replacePath("/Shibboleth.sso/Login").build().toString();
+		}
+		String logoutURL = coreProperties.getProperty("proxy.logout.url");
+		if (logoutURL != null && !logoutURL.trim().isEmpty()) {
+			samlLogoutURL = logoutURL.trim();
+		} else {
+			samlLogoutURL = UriComponentsBuilder.fromHttpUrl(configBean.getIssuer()).replacePath("/Shibboleth.sso/Logout").build().toString();
+		}
+	}
+
+	//called when all beans are initialized, but twice, once for root context and once for spring-servlet
+	@EventListener
+	public void handleContextRefresh(ContextRefreshedEvent event) {
+		if (event.getApplicationContext().getParent() == null) {
+			//log info
+			log.info("Perun OIDC initialized");
+			log.info("Mitreid config URL: {}", configBean.getIssuer());
+			log.info("RPC URL: {}", rpcUrl);
+			log.info("JSON Web Keys: {}", jwk);
+			log.info("JDBC URL: {}", jdbcUrl);
+			log.info("LDAP: ldaps://{}/{}", coreProperties.getProperty("ldap.host"), coreProperties.getProperty("ldap.baseDN"));
+			log.info("THEME: {}", theme);
+			log.info("Registrar URL: {}", registrarUrl);
+			log.info("LOGIN  URL: {}", samlLoginURL);
+			log.info("LOGOUT URL: {}", samlLogoutURL);
+			log.info("accessTokenClaimsModifier: {}", coreProperties.getProperty("accessTokenClaimsModifier"));
+			log.info("Proxy EXT_SOURCE name: {}", proxyExtSourceName);
+			log.info("MitreID version: {}", getMitreidVersion());
+			log.info("Perun OIDC version: {}", getPerunOIDCVersion());
+		}
 	}
 }

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
@@ -116,7 +116,6 @@ public class PerunOidcConfig {
 		return samlLogoutURL;
 	}
 
-
 	public boolean isAskPerunForIdpFiltersEnabled() {
 		return askPerunForIdpFiltersEnabled;
 	}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/ElixirAccessTokenModifier.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/ElixirAccessTokenModifier.java
@@ -13,19 +13,19 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * Implements adding EGA dataset permissions into signed JWT access tokens.
+ * Implements changes required by GA4GH specification followed by the ELIXIR AAI.
  *
  * @author Martin Kuba makub@ics.muni.cz
  */
 @SuppressWarnings("unused")
-public class DatasetPermissionsAccessTokenModifier implements PerunAccessTokenEnhancer.AccessTokenClaimsModifier {
+public class ElixirAccessTokenModifier implements PerunAccessTokenEnhancer.AccessTokenClaimsModifier {
 
-	private final static Logger log = LoggerFactory.getLogger(DatasetPermissionsAccessTokenModifier.class);
+	private final static Logger log = LoggerFactory.getLogger(ElixirAccessTokenModifier.class);
 
 	private static final String GA4GH = "ga4gh"; //Global Alliance for Genomics and Health
 	private static final String GA4GH_USERINFO_CLAIMS = "ga4gh_userinfo_claims";
 
-	public DatasetPermissionsAccessTokenModifier() {
+	public ElixirAccessTokenModifier() {
 	}
 
 	@Override

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthenticationFilter.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthenticationFilter.java
@@ -9,7 +9,6 @@ import cz.muni.ics.oidc.server.connectors.PerunConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 
 import javax.servlet.FilterChain;
@@ -210,7 +209,7 @@ public class PerunAuthenticationFilter extends AbstractPreAuthenticatedProcessin
 		returnURL = URLEncoder.encode(returnURL, String.valueOf(StandardCharsets.UTF_8));
 
 		StringBuilder builder = new StringBuilder();
-		builder.append(config.getLoginUrl());
+		builder.append(config.getSamlLoginURL());
 		builder.append("?target=").append(returnURL);
 
 		if (idpEntityId != null) {

--- a/oidc-idp/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
+++ b/oidc-idp/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright 2018 The MIT Internet Trust Consortium
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.mitre.openid.connect.web;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import cz.muni.ics.oidc.server.configurations.PerunOidcConfig;
+import org.mitre.jwt.assertion.impl.SelfAssertionValidator;
+import org.mitre.oauth2.model.ClientDetailsEntity;
+import org.mitre.oauth2.service.ClientDetailsEntityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.common.exceptions.InvalidClientException;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.text.ParseException;
+
+/**
+ * End Session Endpoint from OIDC session management.
+ * <p>
+ * This is a copy of the original file with modification at the end of processLogout().
+ */
+@Controller
+public class EndSessionEndpoint {
+
+	public static final String URL = "endsession";
+
+	private static final String CLIENT_KEY = "client";
+	private static final String STATE_KEY = "state";
+	private static final String REDIRECT_URI_KEY = "redirectUri";
+
+	private static Logger logger = LoggerFactory.getLogger(EndSessionEndpoint.class);
+
+	@Autowired
+	private SelfAssertionValidator validator;
+
+	@Autowired
+	private PerunOidcConfig perunOidcConfig;
+
+	@Autowired
+	private ClientDetailsEntityService clientService;
+
+	@RequestMapping(value = "/" + URL, method = RequestMethod.GET)
+	public String endSession(@RequestParam(value = "id_token_hint", required = false) String idTokenHint,
+	                         @RequestParam(value = "post_logout_redirect_uri", required = false) String postLogoutRedirectUri,
+	                         @RequestParam(value = STATE_KEY, required = false) String state,
+	                         HttpServletRequest request,
+	                         HttpServletResponse response,
+	                         HttpSession session,
+	                         Authentication auth, Model m) {
+
+		// conditionally filled variables
+		JWTClaimsSet idTokenClaims = null; // pulled from the parsed and validated ID token
+		ClientDetailsEntity client = null; // pulled from ID token's audience field
+
+		if (!Strings.isNullOrEmpty(postLogoutRedirectUri)) {
+			session.setAttribute(REDIRECT_URI_KEY, postLogoutRedirectUri);
+		}
+		if (!Strings.isNullOrEmpty(state)) {
+			session.setAttribute(STATE_KEY, state);
+		}
+
+		// parse the ID token hint to see if it's valid
+		if (!Strings.isNullOrEmpty(idTokenHint)) {
+			try {
+				JWT idToken = JWTParser.parse(idTokenHint);
+
+				if (validator.isValid(idToken)) {
+					// we issued this ID token, figure out who it's for
+					idTokenClaims = idToken.getJWTClaimsSet();
+
+					String clientId = Iterables.getOnlyElement(idTokenClaims.getAudience());
+
+					client = clientService.loadClientByClientId(clientId);
+
+					// save a reference in the session for us to pick up later
+					//session.setAttribute("endSession_idTokenHint_claims", idTokenClaims);
+					session.setAttribute(CLIENT_KEY, client);
+				}
+			} catch (ParseException e) {
+				// it's not a valid ID token, ignore it
+				logger.debug("Invalid id token hint", e);
+			} catch (InvalidClientException e) {
+				// couldn't find the client, ignore it
+				logger.debug("Invalid client", e);
+			}
+		}
+
+		// are we logged in or not?
+		if (auth == null || !request.isUserInRole("ROLE_USER")) {
+			// we're not logged in anyway, process the final redirect bits if needed
+			return processLogout(null, request, response, session, auth, m);
+		} else {
+			logger.info("Logout confirmating for user {} from client {}", auth.getName(), client != null ? client.getClientName() : "unknown");
+			// we are logged in, need to prompt the user before we log out
+			m.addAttribute("client", client);
+			m.addAttribute("idToken", idTokenClaims);
+
+			// display the log out confirmation page
+			return "logoutConfirmation";
+		}
+	}
+
+	@RequestMapping(value = "/" + URL, method = RequestMethod.POST)
+	public String processLogout(@RequestParam(value = "approve", required = false) String approved,
+	                            HttpServletRequest request,
+	                            HttpServletResponse response,
+	                            HttpSession session,
+	                            Authentication auth, Model m) {
+
+		String redirectUri = (String) session.getAttribute(REDIRECT_URI_KEY);
+		String state = (String) session.getAttribute(STATE_KEY);
+		ClientDetailsEntity client = (ClientDetailsEntity) session.getAttribute(CLIENT_KEY);
+
+		if (!Strings.isNullOrEmpty(approved)) {
+			// use approved, perform the logout
+			if (auth != null) {
+				new SecurityContextLogoutHandler().logout(request, response, auth);
+			}
+			SecurityContextHolder.getContext().setAuthentication(null);
+		}
+
+		String redirectURL = null;
+
+		// if we have a client AND the client has post-logout redirect URIs
+		// registered AND the URI given is in that list, then...
+		if (!Strings.isNullOrEmpty(redirectUri) &&
+				client != null && client.getPostLogoutRedirectUris() != null) {
+
+			if (client.getPostLogoutRedirectUris().contains(redirectUri)) {
+				UriComponents uri = UriComponentsBuilder.fromHttpUrl(redirectUri).queryParam("state", state).build();
+				logger.trace("redirect URL: {}", uri);
+				redirectURL = uri.toString();
+			}
+		}
+
+		String samlLogoutURL = perunOidcConfig.getSamlLogoutURL();
+		if (redirectURL != null) {
+			logger.trace("redirecting to logout SAML and then {}", redirectURL);
+			return "redirect:" + UriComponentsBuilder.fromHttpUrl(samlLogoutURL).queryParam("return", redirectURL).build();
+		} else {
+			logger.trace("redirecting to logout SAML only");
+			return "redirect:" + samlLogoutURL;
+		}
+	}
+
+}

--- a/oidc-idp/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
+++ b/oidc-idp/src/main/java/org/mitre/openid/connect/web/EndSessionEndpoint.java
@@ -49,6 +49,7 @@ import java.text.ParseException;
  * End Session Endpoint from OIDC session management.
  * <p>
  * This is a copy of the original file with modification at the end of processLogout().
+ * </p>
  */
 @Controller
 public class EndSessionEndpoint {

--- a/oidc-idp/src/main/resources/logback.xml
+++ b/oidc-idp/src/main/resources/logback.xml
@@ -54,5 +54,6 @@
 	<logger name="cz.muni.ics.oidc.server.PerunAccessTokenEnhancer" level="warn"/>
 	<logger name="cz.muni.ics.oidc.server.PerunAuthenticationUserDetailsService" level="info"/>
 <!--	<logger name="cz.muni.ics.oidc.server.elixir.GA4GHClaimSource" level="trace"/>-->
+	<logger name="org.mitre.openid.connect.web.EndSessionEndpoint" level="trace"/>
 
 </configuration>

--- a/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
+++ b/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
@@ -22,7 +22,6 @@
 				<prop key="main.oidc.issuer.url">https://perun-dev.meta.zcu.cz/oidc/</prop>
 				<prop key="logo.image.url">resources/images/perun_24px.png</prop>
 				<prop key="topbar.title">Perun OIDC</prop>
-				<prop key="proxy.login.url">https://login.cesnet.cz/Shibboleth.sso/Login</prop>
 				<prop key="proxy.extSource.name"/>
 				<prop key="perun.rpc.url">https://perun.elixir-czech.cz/krb/rpc</prop>
 				<prop key="perun.rpc.user">xxxxx</prop>
@@ -143,7 +142,6 @@
 		<property name="jdbcUrl" value="${jdbc.url}"/>
 		<property name="theme" value="${web.theme}"/>
 		<property name="registrarUrl" value="${registrar.url}"/>
-		<property name="loginUrl" value="${proxy.login.url}"/>
 		<property name="askPerunForIdpFiltersEnabled" value="${idpFilters.askPerun.enabled}"/>
 		<property name="proxyExtSourceName" value="${proxy.extSource.name}"/>
 	</bean>


### PR DESCRIPTION
- modified EndSessionEndpoint to redirect to SAML logout after OIDC logout and before redirect back to client
- added property proxy.logout.url that may specify non-standard logout URL
- if properties proxy.logout.url or proxy.login.url are not defined, standard shibboleth URLs are created from the OIDC issuer URL (by replacing path with /Shibboleth.sso/Logout or /Shibboleth.sso/Login)
- renamed DatasetPermissionsAccessTokenModifier to ElixirAccessTokenModifier to better match its purpose