### PR TITLE
set GA4GH affiliations expiration based on lastAccess

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/connectors/impl/PerunConnectorRpc.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/connectors/impl/PerunConnectorRpc.java
@@ -296,14 +296,14 @@ public class PerunConnectorRpc implements PerunConnector {
 			if (extSource.path("type").asText().equals("cz.metacentrum.perun.core.impl.ExtSourceIdp")) {
 				long id = ues.path("id").asLong();
 				String login = ues.path("login").asText();
+				long asserted = Timestamp.valueOf(ues.path("lastAccess").asText()).getTime() / 1000L;
 				String name = extSource.path("name").asText();
 				log.trace("ues id={},name={},login={}", id, name, login);
 				PerunAttribute perunAttribute = Mapper.mapAttribute(makeRpcCall("/attributesManager/getAttribute", ImmutableMap.of("userExtSource", id, "attributeName", attributeName)));
 				String value = perunAttribute.valueAsString();
 				if (value != null) {
-					long linuxTime = Timestamp.valueOf(perunAttribute.getValueModifiedAt()).getTime() / 1000L;
 					for (String v : value.split(";")) {
-						Affiliation affiliation = new Affiliation(name, v, linuxTime);
+						Affiliation affiliation = new Affiliation(name, v, asserted);
 						log.debug("found {} from IdP {} with modif time {}", v, name, perunAttribute.getValueModifiedAt());
 						affiliations.add(affiliation);
 					}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHClaimSource.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHClaimSource.java
@@ -122,7 +122,8 @@ public class GA4GHClaimSource extends ClaimSource {
 		//by=system for users with affiliation asserted by their IdP (set in UserExtSource attribute "affiliation")
 		StringBuilder sb = new StringBuilder("Affiliations: ");
 		for (Affiliation affiliation : affiliations) {
-			long expires = ZonedDateTime.now().plusYears(1L).toEpochSecond();//values are not updated, setting one year in the future
+			//expires 1 year after the last login from the IdP asserting the affiliation
+			long expires = Instant.ofEpochSecond(affiliation.getAsserted()).atZone(ZoneId.systemDefault()).plusYears(1L).toEpochSecond();
 			sb.append(affiliation.getValue()).append(",");
 			affiliationAndRole.add(createRIClaim(affiliation.getValue(), affiliation.getSource(), "system", affiliation.getAsserted(), expires, null));
 		}
@@ -142,7 +143,7 @@ public class GA4GHClaimSource extends ClaimSource {
 			} else {
 				asserted = System.currentTimeMillis() / 1000L;
 			}
-			long expires = ZonedDateTime.ofInstant(Instant.ofEpochSecond(asserted), ZoneId.systemDefault()).plusYears(100L).toEpochSecond();
+			long expires = Instant.ofEpochSecond(asserted).atZone(ZoneId.systemDefault()).plusYears(100L).toEpochSecond();
 			acceptedTermsAndPolicies.add(createRIClaim(BONA_FIDE_URL, NO_ORG_URL, "self", asserted, expires, null));
 			return acceptedTermsAndPolicies.textNode("terms accepted on " + isoDate(asserted));
 		} else {
@@ -164,7 +165,7 @@ public class GA4GHClaimSource extends ClaimSource {
 		//by=system for users with faculty affiliation asserted by their IdP (set in UserExtSource attribute "affiliation")
 		for (Affiliation affiliation : affiliations) {
 			if (affiliation.getValue().startsWith("faculty@")) {
-				long expires = ZonedDateTime.now().plusYears(1L).toEpochSecond();
+				long expires = Instant.ofEpochSecond(affiliation.getAsserted()).atZone(ZoneId.systemDefault()).plusYears(1L).toEpochSecond();
 				researcherStatus.add(createRIClaim(BONA_FIDE_URL, affiliation.getValue() + " " + affiliation.getSource(), "system", affiliation.getAsserted(), expires, null));
 				sb.append("system as affiliation ").append(affiliation.getValue()).append(" on ").append(isoDate(affiliation.getAsserted()));
 			}


### PR DESCRIPTION
Since Perun 3.6, the lastAccess field of UserExtSource keeps the last time its atribute values were written or found to be unchanged. So it can be used for setting the "asserted" field in GA4GH claim objects holding affiliations.