### PR TITLE
Fix in DB for SQL exception

### DIFF
--- a/oidc-idp/src/main/webapp/WEB-INF/classes/db/mysql/db_update.sql
+++ b/oidc-idp/src/main/webapp/WEB-INF/classes/db/mysql/db_update.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS authentication_holder_request_parameter
+MODIFY COLUMN val TEXT;

--- a/oidc-idp/src/main/webapp/WEB-INF/classes/db/psql/psql_database_tables.sql
+++ b/oidc-idp/src/main/webapp/WEB-INF/classes/db/psql/psql_database_tables.sql
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS authentication_holder_scope (
 CREATE TABLE IF NOT EXISTS authentication_holder_request_parameter (
 	owner_id BIGINT,
 	param VARCHAR(2048),
-	val VARCHAR(2048)
+	val TEXT
 );
 
 CREATE TABLE IF NOT EXISTS saved_user_auth (


### PR DESCRIPTION
- Changed type VARCHAR(2048) in table "authentication_holder_request_parameter" to use TEXT type.
- When using renew on testing client, MITREid tried to store the request parameter into DB. Request parameter was id_token_hint, which was too long. TEXT data type can handle it.