### PR TITLE
configurable scopes for including claims into id_token

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
@@ -12,6 +12,7 @@ import javax.annotation.PostConstruct;
 import javax.servlet.ServletContext;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Configuration of OIDC server in context of Perun.
@@ -36,6 +37,7 @@ public class PerunOidcConfig {
 	private String perunOIDCVersion;
 	private String mitreidVersion;
 	private String proxyExtSourceName;
+	private Set<String> idTokenScopes;
 
 	@Autowired
 	private ServletContext servletContext;
@@ -73,6 +75,18 @@ public class PerunOidcConfig {
 
 	public void setRegistrarUrl(String registrarUrl) {
 		this.registrarUrl = registrarUrl;
+	}
+
+
+
+
+	public void setIdTokenScopes(Set<String> idTokenScopes) {
+		this.idTokenScopes = idTokenScopes;
+	}
+
+
+	public Set<String> getIdTokenScopes() {
+		return idTokenScopes;
 	}
 
 	public String getPerunOIDCVersion() {
@@ -174,4 +188,5 @@ public class PerunOidcConfig {
 			log.info("Perun OIDC version: {}", getPerunOIDCVersion());
 		}
 	}
+
 }

--- a/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
+++ b/oidc-idp/src/main/webapp/WEB-INF/user-context.xml
@@ -50,6 +50,7 @@
 				<prop key="web.theme">default</prop>
 				<prop key="idpFilters.askPerun.enabled">false</prop>
 				<prop key="registrar.url">https://perun-dev.cesnet.cz/allfed/registrar/</prop>
+				<prop key="id_token.scopes">openid,profile,email,phone,address</prop>
 				<prop key="facility.attrs.checkGroupMembership">urn:perun:facility:attribute-def:def:OIDCCheckGroupMembership</prop>
 				<prop key="facility.attrs.allowRegistration">urn:perun:facility:attribute-def:def:allowRegistration</prop>
 				<prop key="facility.attrs.registrationURL">urn:perun:facility:attribute-def:def:registrationURL</prop>
@@ -144,6 +145,7 @@
 		<property name="registrarUrl" value="${registrar.url}"/>
 		<property name="askPerunForIdpFiltersEnabled" value="${idpFilters.askPerun.enabled}"/>
 		<property name="proxyExtSourceName" value="${proxy.extSource.name}"/>
+		<property name="idTokenScopes" value="#{'${id_token.scopes}'.split('\s*,\s*')}"/>
 	</bean>
 
 	<bean id="facilityAttrsConfig" class="cz.muni.ics.oidc.server.configurations.FacilityAttrsConfig">


### PR DESCRIPTION
Some non-standard claims are too large to be included into id_token, which needs to be passed in URLs. This pull request makes claims included into id_token configurable. Only claims belonging to scopes configured by id_token.scopes property are included. 

By default, only standard OIDC scopes are configured (openid,profile,email,phone,address).