### PR TITLE
Fixed bug in resource capabilities

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/claims/sources/EntitlementSource.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/claims/sources/EntitlementSource.java
@@ -62,7 +62,7 @@ public class EntitlementSource extends ClaimSource {
 						.getResourceCapabilities(pctx.getClient().getClientId(), groupNames, capabilities);
 
 				for (String capability : resultCapabilities) {
-					result.add(wrapGroupNameToAARC(capability));
+					result.add(wrapCapabilityToAARC(capability));
 				}
 			}
 		}
@@ -76,7 +76,10 @@ public class EntitlementSource extends ClaimSource {
 	}
 
 	private String wrapGroupNameToAARC(String groupName) {
-		return prefix + UrlEscapers.urlPathSegmentEscaper().escape(groupName) + "#" + authority;
+		return prefix + "group:" + UrlEscapers.urlPathSegmentEscaper().escape(groupName) + "#" + authority;
 	}
 
+	private String wrapCapabilityToAARC(String capability) {
+		return prefix + UrlEscapers.urlPathSegmentEscaper().escape(capability) + "#" + authority;
+	}
 }


### PR DESCRIPTION
We added "group:" into resource capabilities while wrapping them. Now it is added just into groups.

Unfortunately, perun-mitreid.properties config file has to be changed. In eduperson_entitlement claim, "group:" has to be removed from "prefix" property.