### PR TITLE
Fixed bugs for Logout force, fixed wrong saml logout URL setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 - Changed logging configuration - log all classes at the level specified while building
 ### Fixed
 - Fixed handling of group "members" in resource capabilities
+- Fixed wrong behavior of MFA forced logout
+- Fixed wrong loading of SAML logout URL when specified in properties
 
 ## [v1.23.0]
 ### Changed

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
@@ -197,7 +197,7 @@ public class PerunOidcConfig {
 		}
 
 		if (samlLogoutURL != null && !samlLogoutURL.trim().isEmpty()) {
-			samlLogoutURL = samlLoginURL.trim();
+			samlLogoutURL = samlLogoutURL.trim();
 		} else {
 			samlLogoutURL = UriComponentsBuilder.fromHttpUrl(configBean.getIssuer()).replacePath("/Shibboleth.sso/Logout").build().toString();
 		}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthenticationFilter.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/PerunAuthenticationFilter.java
@@ -240,19 +240,16 @@ public class PerunAuthenticationFilter extends AbstractPreAuthenticatedProcessin
 
 		if (req.getQueryString() == null) {
 			returnURL = req.getRequestURL().toString();
-			if (loggedOut) {
-				returnURL += ('?' + LOGOUT_PARAM + '=' + true);
-			}
+			returnURL += ('?' + LOGOUT_PARAM + '=' + true);
 		} else {
 			returnURL = req.getRequestURL().toString() + '?' + req.getQueryString();
-			if (loggedOut) {
-				returnURL += ('&' + LOGOUT_PARAM + '=' + true);
-			}
+			returnURL += ('&' + LOGOUT_PARAM + '=' + true);
 		}
 
 		log.trace("buildReturnUrl() returns: {}", returnURL);
 		return returnURL;
 	}
+
 
 	private String buildAuthnContextClassRef(String clientId, HttpServletRequest req) {
 		log.trace("buildAuthnContextClassRef(clientId: {}, req: {})", clientId, req);


### PR DESCRIPTION
- fixed forced logout from SAML when using MFA, sometimes filter has not indicated user has been logged out and the user had to log in twice
- fixed setting of SAML logout URL when specified (bug was that login URL has been used instead)