### PR TITLE
Fixed bad rendering of registration pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Fixed wrong behavior of MFA forced logout
 - Fixed wrong loading of SAML logout URL when specified in properties
 - Fixed wrong handling of date and time because of ignoring time zone (ACR expiration)
+- Fixed bad rendering of registration pages (registration into groups when authorization has failed) - double service name in heading
 
 ## [v1.23.0]
 ### Changed

--- a/oidc-idp/src/main/webapp/WEB-INF/views/registrationForm.jsp
+++ b/oidc-idp/src/main/webapp/WEB-INF/views/registrationForm.jsp
@@ -26,12 +26,14 @@ pageContext.setAttribute("cssLinks", cssLinks);
 <div id="content">
     <div id="head">
         <h1>${fn:escapeXml(langProps['registration_header1'])}
-            <c:if test="${not empty client.clientName and not empty client.clientUri}">
-                &#32;<a href="${fn:escapeXml(client.clientUri)}">${fn:escapeXml(client.clientName)}</a>
-            </c:if>
-            <c:if test="${not empty client.clientName}">
-                &#32;${fn:escapeXml(client.clientName)}
-            </c:if>
+            <c:choose>
+                <c:when test="${not empty client.clientName and not empty client.clientUri}">
+                    &#32;<a href="${fn:escapeXml(client.clientUri)}">${fn:escapeXml(client.clientName)}</a>
+                </c:when>
+                <c:when test="${not empty client.clientName}">
+                    &#32;${fn:escapeXml(client.clientName)}
+                </c:when>
+            </c:choose>
             &#32;${langProps['registration_header2']}
         </h1>
     </div>

--- a/oidc-idp/src/main/webapp/WEB-INF/views/registrationFormContinue.jsp
+++ b/oidc-idp/src/main/webapp/WEB-INF/views/registrationFormContinue.jsp
@@ -26,12 +26,14 @@ pageContext.setAttribute("cssLinks", cssLinks);
 <div id="content">
     <div id="head">
         <h1>${langProps['go_to_registration_header1']}
-            <c:if test="${not empty client.clientName and not empty client.clientUri}">
-                &#32;<a href="${fn:escapeXml(client.uri)}">${fn:escapeXml(client.clientName)}</a>
-            </c:if>
-            <c:if test="${not empty client.clientName}">
-                &#32;${fn:escapeXml(client.clientName)}
-            </c:if>
+            <c:choose>
+                <c:when test="${not empty client.clientName and not empty client.clientUri}">
+                    &#32;<a href="${fn:escapeXml(client.uri)}">${fn:escapeXml(client.clientName)}</a>
+                </c:when>
+                <c:when test="${not empty client.clientName}">
+                    &#32;${fn:escapeXml(client.clientName)}
+                </c:when>
+            </c:choose>
             &#32;${langProps['go_to_registration_header2']}
         </h1>
     </div>


### PR DESCRIPTION
- double service name in heading has been rendered due to usage of c:if instead of c:choose tag