### PR TITLE
Fixed validating url for registrations when unapproved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed wrong loading of SAML logout URL when specified in properties
 - Fixed wrong handling of date and time because of ignoring time zone (ACR expiration)
 - Fixed bad rendering of registration pages (registration into groups when authorization has failed) - double service name in heading
+- Fixed validation of custom registration URL in PerunAuthorizationFilter
 
 ## [v1.23.0]
 ### Changed

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/impl/PerunAuthorizationFilter.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/impl/PerunAuthorizationFilter.java
@@ -160,8 +160,8 @@ public class PerunAuthorizationFilter extends PerunRequestFilter {
 			return null;
 		}
 
-		if (!customRegUrl.startsWith("http://")) {
-			customRegUrl = "http://" + customRegUrl;
+		if (!customRegUrl.startsWith("http://") && !customRegUrl.startsWith("https://")) {
+			customRegUrl = "https://" + customRegUrl;
 		}
 
 		try {
@@ -170,10 +170,10 @@ public class PerunAuthorizationFilter extends PerunRequestFilter {
 			conn.connect();
 			return customRegUrl;
 		} catch (IOException e) {
-			//this is ok, we can try add https:// to the url
+			//this is ok, we can try to replace https:// with http://
 		}
 
-		customRegUrl = customRegUrl.replace("http://", "https://");
+		customRegUrl = customRegUrl.replace("https://", "http://");
 
 		try {
 			URL url = new URL(customRegUrl);


### PR DESCRIPTION
- ficxed validation of custom URL provided when user does not meet criteria to access the service and should be redirected to custom registration URL
- old implementation tried to add http:// at the start of string even when https:// has been present, resulting in wrongly formated URL
- changed order of validation, first try HTTPS then HTTP
