### PR TITLE
Skip forwarded entitlements if attr not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Changed property names for specifying custom claims (see configuration template for required format)
 - UserInfo modifiers are now loaded only at the startup, previously were loaded for each modification separately
+- Changed EntitlementSource, if forwardedEntitlements attribute name is not specified, the forwarded entitlements will not be added to the list
 ### Fixed
 - Fixed possible null pointer exceptions and wrong behavior for FilterEduPersonEntitlement UserInfo modifier
 

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/claims/sources/EntitlementSource.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/claims/sources/EntitlementSource.java
@@ -12,9 +12,10 @@ import java.util.Set;
 
 /**
  * This source converts groupNames and resource capabilities to AARC format and joins them with eduPersonEntitlement
- * Configuration (replace [claimName] with claimName defined for source):
+ * Configuration (replace [claimName] with claimName defined for the source):
  * - custom.claim.[claimName].groupNames - groupNames attribute name
- * - custom.claim.[claimName].eduPersonEntitlement - eduPersonEntitlement attribute name
+ * - custom.claim.[claimName].forwardedEntitlements - forwardedEntitlements attribute name, if not specified, the forwarded
+ * entitlements will not be added to the list
  * - custom.claim.[claimName].capabilities - capabilities attribute name
  * - custom.claim.[claimName].prefix - prefix added before name of group
  * - custom.claim.[claimName].authority - source of claim
@@ -32,7 +33,7 @@ public class EntitlementSource extends ClaimSource {
 	public EntitlementSource(ClaimSourceInitContext ctx) {
 		super(ctx);
 		groupNames = ctx.getProperty("groupNames", null);
-		eduPersonEntitlement = ctx.getProperty("eduPersonEntitlement", null);
+		eduPersonEntitlement = ctx.getProperty("forwardedEntitlements", null);
 		capabilities = ctx.getProperty("capabilities", null);
 		prefix = ctx.getProperty("prefix", null);
 		authority = ctx.getProperty("authority", null);
@@ -42,7 +43,6 @@ public class EntitlementSource extends ClaimSource {
 	public JsonNode produceValue(ClaimSourceProduceContext pctx) {
 
 		JsonNode groupNamesJson = pctx.getRichUser().getJson(groupNames);
-		JsonNode eduPersonEntitlementJson = pctx.getRichUser().getJson(eduPersonEntitlement);
 
 		JsonNodeFactory factory = JsonNodeFactory.instance;
 		ArrayNode result = new ArrayNode(factory);
@@ -67,9 +67,13 @@ public class EntitlementSource extends ClaimSource {
 			}
 		}
 
-		if (eduPersonEntitlementJson != null) {
-			ArrayNode eduPersonEntitlementArrayNode = (ArrayNode) eduPersonEntitlementJson;
-			result.addAll(eduPersonEntitlementArrayNode);
+		if (this.eduPersonEntitlement != null && !this.eduPersonEntitlement.trim().isEmpty()) {
+			JsonNode eduPersonEntitlementJson = pctx.getRichUser().getJson(eduPersonEntitlement);
+
+			if (eduPersonEntitlementJson != null) {
+				ArrayNode eduPersonEntitlementArrayNode = (ArrayNode) eduPersonEntitlementJson;
+				result.addAll(eduPersonEntitlementArrayNode);
+			}
 		}
 
 		return result;


### PR DESCRIPTION
- When property eduPersonEntitlement in EntitlementSource is null or
blank, producing value will ignore the attribute with forwarded
entitlements
