### PR TITLE
Added ShedLock support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
+- Added support for ShedLock in scheduled tasks
+- Added DB table for ShedLock, see SQL scripts for the table definition that needs to be created
 - Added service name to the consent header
 ### Changed
+- Overridden calling of scheduled task from MitreID with our custom class
 - Changed property names for specifying custom claims (see configuration template for required format)
 - UserInfo modifiers are now loaded only at the startup, previously were loaded for each modification separately
 - Changed EntitlementSource, if forwardedEntitlements attribute name is not specified, the forwarded entitlements will not be added to the list
 ### Fixed
+- When used in clustered environment, running scheduled task caused DeadLocks to appear in DB
 - Fixed possible null pointer exceptions and wrong behavior for FilterEduPersonEntitlement UserInfo modifier
 
 ## [v1.24.0]

--- a/oidc-idp/pom.xml
+++ b/oidc-idp/pom.xml
@@ -136,6 +136,18 @@
 			<version>1.7.25</version>
 		</dependency>
 
+		<!-- ShedLock -->
+		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-spring</artifactId>
+			<version>4.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>net.javacrumbs.shedlock</groupId>
+			<artifactId>shedlock-provider-jdbc-template</artifactId>
+			<version>4.3.1</version>
+		</dependency>
+
 		<!-- @Resource and @PostConstruct for Java 11 -->
 		<dependency>
 			<groupId>javax.annotation</groupId>

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/CustomTaskScheduler.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/CustomTaskScheduler.java
@@ -1,0 +1,125 @@
+package cz.muni.ics.oidc.server;
+
+import net.javacrumbs.shedlock.core.LockAssert;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.mitre.oauth2.service.DeviceCodeService;
+import org.mitre.oauth2.service.OAuth2TokenEntityService;
+import org.mitre.oauth2.service.impl.DefaultOAuth2AuthorizationCodeService;
+import org.mitre.openid.connect.service.ApprovedSiteService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import javax.sql.DataSource;
+
+/**
+ * A custom scheduler for tasks with usage of ShedLock.
+ *
+ * @author Dominik Frantisek Bucik <bucik@ics.muni.cz>
+ */
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "30s")
+public class CustomTaskScheduler {
+
+	private static final Logger log = LoggerFactory.getLogger(CustomTaskScheduler.class);
+
+	private OAuth2TokenEntityService tokenEntityService;
+	private ApprovedSiteService approvedSiteService;
+	private DefaultOAuth2AuthorizationCodeService defaultOAuth2AuthorizationCodeService;
+	private DeviceCodeService deviceCodeService;
+	private PerunAcrRepository perunAcrRepository;
+	private DataSource dataSource;
+
+	@Autowired
+	public void setTokenEntityService(OAuth2TokenEntityService tokenEntityService) {
+		this.tokenEntityService = tokenEntityService;
+	}
+
+	@Autowired
+	public void setApprovedSiteService(ApprovedSiteService approvedSiteService) {
+		this.approvedSiteService = approvedSiteService;
+	}
+
+	@Autowired
+	public void setAuthorizationCodeServices(DefaultOAuth2AuthorizationCodeService defaultOAuth2AuthorizationCodeService) {
+		this.defaultOAuth2AuthorizationCodeService = defaultOAuth2AuthorizationCodeService;
+	}
+
+	@Autowired
+	public void setDeviceCodeService(DeviceCodeService deviceCodeService) {
+		this.deviceCodeService = deviceCodeService;
+	}
+
+	@Autowired
+	public void setPerunAcrRepository(PerunAcrRepository perunAcrRepository) {
+		this.perunAcrRepository = perunAcrRepository;
+	}
+
+	@Autowired
+	public void setDataSource(@Qualifier("dataSource") DataSource dataSource) {
+		this.dataSource = dataSource;
+	}
+
+	public CustomTaskScheduler() {
+		log.info("CustomTasksSchedulerCreated");
+	}
+
+	@Bean
+	public LockProvider lockProvider() {
+		return new JdbcTemplateLockProvider(this.dataSource);
+	}
+
+	@Scheduled(fixedDelay = 300000L, initialDelay = 600000L)
+	@SchedulerLock(name = "clearExpiredTokens")
+	public void clearExpiredTokens() {
+		log.debug("clearExpiredTokens");
+		LockAssert.assertLocked();
+		this.tokenEntityService.clearExpiredTokens();
+		log.debug("clearExpiredTokens - ends");
+	}
+
+	@Scheduled(fixedDelay = 300000L, initialDelay = 600000L)
+	@SchedulerLock(name = "clearExpiredSites")
+	public void clearExpiredSites() {
+		log.debug("clearExpiredSites");
+		LockAssert.assertLocked();
+		this.approvedSiteService.clearExpiredSites();
+		log.debug("clearExpiredSites - ends");
+	}
+
+	@Scheduled(fixedDelay = 300000L, initialDelay = 600000L)
+	@SchedulerLock(name = "clearExpiredAuthorizationCodes")
+	public void clearExpiredAuthorizationCodes() {
+		log.debug("clearExpiredAuthorizationCodes");
+		LockAssert.assertLocked();
+		this.defaultOAuth2AuthorizationCodeService.clearExpiredAuthorizationCodes();
+		log.debug("clearExpiredAuthorizationCodes - ends");
+	}
+
+	@Scheduled(fixedDelay = 300000L, initialDelay = 600000L)
+	@SchedulerLock(name = "clearExpiredDeviceCodes")
+	public void clearExpiredDeviceCodes() {
+		log.debug("clearExpiredDeviceCodes");
+		LockAssert.assertLocked();
+		this.deviceCodeService.clearExpiredDeviceCodes();
+		log.debug("clearExpiredDeviceCodes - ends");
+	}
+
+	@Scheduled(fixedDelay = 600000L, initialDelay = 600000L)
+	@SchedulerLock(name = "clearExpiredAcrs")
+	public void clearExpiredAcrs() {
+		log.debug("clearExpiredAcrs");
+		LockAssert.assertLocked();
+		this.perunAcrRepository.deleteExpired();
+		log.debug("clearExpiredAcrs - ends");
+	}
+}

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/PerunAcrRepository.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/PerunAcrRepository.java
@@ -3,7 +3,6 @@ package cz.muni.ics.oidc.server;
 import org.mitre.openid.connect.models.Acr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,7 +72,6 @@ public class PerunAcrRepository {
 	}
 
 	@Transactional
-	@Scheduled(fixedDelay = 600000)
 	public void deleteExpired() {
 		log.trace("deleteExpired()");
 		Query query = manager.createNamedQuery(Acr.DELETE_EXPIRED);

--- a/oidc-idp/src/main/resources/logback.xml
+++ b/oidc-idp/src/main/resources/logback.xml
@@ -49,5 +49,6 @@
 	<!-- PASSED FROM POM.XML / MAVEN BUILD PROPS -->
 	<logger name="cz.muni.ics.oidc" level="${log.level}"/>
 	<logger name="org.mitre.openid.connect.web.EndSessionEndpoint" level="${log.level}"/>
+	<logger name="net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateStorageAccessor" level="error"/>
 
 </configuration>

--- a/oidc-idp/src/main/webapp/WEB-INF/classes/db/psql/db_update.sql
+++ b/oidc-idp/src/main/webapp/WEB-INF/classes/db/psql/db_update.sql
@@ -1,6 +1,3 @@
-ALTER TABLE authentication_holder_request_parameter
-MODIFY COLUMN val TEXT;
-
 CREATE TABLE shedlock(
     name VARCHAR(64),
     lock_until TIMESTAMP(3) NULL,

--- a/oidc-idp/src/main/webapp/WEB-INF/task-config.xml
+++ b/oidc-idp/src/main/webapp/WEB-INF/task-config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
+
+</beans>


### PR DESCRIPTION
- When used in clustered environment, running scheduled task caused
DeadLocks to appear in DB
- ShedLock provides support for locking by inserting records into
special table
- !!!IMPORTANT: needs new table in DB, see SQL scripts for change!!!
