### PR TITLE
Fixed typo in Shedlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - When used in clustered environment, running scheduled task caused DeadLocks to appear in DB
 - Fixed possible null pointer exceptions and wrong behavior for FilterEduPersonEntitlement UserInfo modifier
+- Fixed typo in database table for Shedlock (column 'ocked_at' changed to 'locked_at')
 
 ## [v1.24.0]
 ### Added

--- a/oidc-idp/src/main/webapp/WEB-INF/classes/db/mysql/db_update.sql
+++ b/oidc-idp/src/main/webapp/WEB-INF/classes/db/mysql/db_update.sql
@@ -4,7 +4,7 @@ MODIFY COLUMN val TEXT;
 CREATE TABLE shedlock(
     name VARCHAR(64),
     lock_until TIMESTAMP(3) NULL,
-    ocked_at TIMESTAMP(3) NULL,
+    locked_at TIMESTAMP(3) NULL,
     locked_by  VARCHAR(255),
     PRIMARY KEY (name)
 );

--- a/oidc-idp/src/main/webapp/WEB-INF/classes/db/psql/db_update.sql
+++ b/oidc-idp/src/main/webapp/WEB-INF/classes/db/psql/db_update.sql
@@ -1,7 +1,7 @@
 CREATE TABLE shedlock(
     name VARCHAR(64),
     lock_until TIMESTAMP(3) NULL,
-    ocked_at TIMESTAMP(3) NULL,
+    locked_at TIMESTAMP(3) NULL,
     locked_by  VARCHAR(255),
     PRIMARY KEY (name)
 );


### PR DESCRIPTION
- changed column name 'ocked_at' to 'locked_at'
