### PR TITLE
changed GA4GHClaimsSource config format to YAML

### DIFF
--- a/oidc-idp/pom.xml
+++ b/oidc-idp/pom.xml
@@ -99,6 +99,11 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.9</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+			<version>2.9.8</version>
+		</dependency>
 		<!-- MySQL JDBC driver -->
 		<dependency>
 			<groupId>org.mariadb.jdbc</groupId>

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHTokenParser.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHTokenParser.java
@@ -27,6 +27,7 @@ public class GA4GHTokenParser {
 	static ObjectMapper jsonMapper = new ObjectMapper();
 
 	public static void main(String[] args) throws IOException, ParseException, JOSEException {
+		GA4GHClaimSource.parseConfigFile("ga4gh_config.yml");
 		String userinfo = "/tmp/ga4gh.json";
 		JsonNode doc = jsonMapper.readValue(new File(userinfo), JsonNode.class);
 		JsonNode ga4gh = doc.get("ga4gh_passport_v1");


### PR DESCRIPTION
To enable any number of GA4GH Claim Repositories, the configuration of the GA4GHClaimSource was moved to a separate YAML-formatted file.