### PR TITLE
fixed bug for two different URLs to be equal in HashMap

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHClaimSource.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHClaimSource.java
@@ -82,7 +82,7 @@ public class GA4GHClaimSource extends ClaimSource {
 	private final URI jku;
 	private final String issuer;
 	private static final List<ClaimRepository> claimRepositories = new ArrayList<>();
-	private static final Map<URL, RemoteJWKSet<SecurityContext>> remoteJwkSets = new HashMap<>();
+	private static final Map<URI, RemoteJWKSet<SecurityContext>> remoteJwkSets = new HashMap<>();
 	private static final Map<URI, String> signers = new HashMap<>();
 
 	public GA4GHClaimSource(ClaimSourceInitContext ctx) throws URISyntaxException {
@@ -125,7 +125,7 @@ public class GA4GHClaimSource extends ClaimSource {
 				String jwks = signer.path("jwks").asText();
 				try {
 					URL jku = new URL(jwks);
-					remoteJwkSets.put(jku, new RemoteJWKSet<>(jku));
+					remoteJwkSets.put(jku.toURI(), new RemoteJWKSet<>(jku));
 					signers.put(jku.toURI(), name);
 					log.info("JWKS Signer " + name + " added with keys " + jwks);
 				} catch (MalformedURLException | URISyntaxException e) {
@@ -299,7 +299,7 @@ public class GA4GHClaimSource extends ClaimSource {
 				return visa;
 			}
 			visa.setSigner(signers.get(jku));
-			RemoteJWKSet<SecurityContext> remoteJWKSet = remoteJwkSets.get(jku.toURL());
+			RemoteJWKSet<SecurityContext> remoteJWKSet = remoteJwkSets.get(jku);
 			if (remoteJWKSet == null) {
 				log.error("JKU {} is not among trusted key sets", jku);
 				return visa;

--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHTokenParser.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/elixir/GA4GHTokenParser.java
@@ -2,6 +2,7 @@ package cz.muni.ics.oidc.server.elixir;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.jwt.SignedJWT;
@@ -44,8 +45,14 @@ public class GA4GHTokenParser {
 			} else {
 				System.out.println("OK: "+visa.getPrettyString());
 			}
-			JsonNode visadoc = jsonMapper.readValue(((SignedJWT) JWTParser.parse(visa.getJwt())).getPayload().toString(), JsonNode.class);
-			System.out.println(jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(visadoc));
+			SignedJWT jwt = (SignedJWT) JWTParser.parse(s);
+			ObjectWriter prettyPrinter = jsonMapper.writerWithDefaultPrettyPrinter();
+
+			JsonNode visaHeader = jsonMapper.readValue(jwt.getHeader().toString(), JsonNode.class);
+			System.out.println(prettyPrinter.writeValueAsString(visaHeader));
+
+			JsonNode visaPayload = jsonMapper.readValue(jwt.getPayload().toString(), JsonNode.class);
+			System.out.println(prettyPrinter.writeValueAsString(visaPayload));
 		}
 		long endx = System.currentTimeMillis();
 		System.out.println("signature verification time: " + (endx - startx));


### PR DESCRIPTION
The java.net.URL.equals() method considers two different URLs to be equal if their hostnames resolve to the same IP address, which is obviously a broken behavior since the invention of name-based virtual web sites sharing a single IP address. Unfortunately this bug manifested itself when two URLs from CSC were added for JWKS. 

This fix used URI instead of URLs.