### PR TITLE
Shorter session ID in the MDC log

### DIFF
--- a/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/impl/MDCFilter.java
+++ b/oidc-idp/src/main/java/cz/muni/ics/oidc/server/filters/impl/MDCFilter.java
@@ -15,18 +15,24 @@ import java.io.IOException;
 public class MDCFilter extends GenericFilterBean {
 
     public static final Logger log = LoggerFactory.getLogger(MDCFilter.class);
+    private static final int SIZE = 12;
+    private static final String SESSION_ID = "sessionID";
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         try {
             HttpServletRequest req = (HttpServletRequest) servletRequest;
             if (req.getSession() != null) {
-                MDC.put("sessionID", req.getSession().getId());
-                log.debug("set sessionID {} for remote user {}", req.getSession().getId(), req.getRemoteUser());
+                String id = req.getSession().getId();
+                if (id != null && id.length() > SIZE) {
+                    id = id.substring(0, SIZE);
+                }
+                log.debug("set sessionID {} for remote user {}", id, req.getRemoteUser());
+                MDC.put(SESSION_ID, id);
             }
             filterChain.doFilter(servletRequest, servletResponse);
         } finally {
-            MDC.remove("sessionID");
+            MDC.remove(SESSION_ID);
         }
     }
 


### PR DESCRIPTION
- the long session ID has been causing problems when parsing in syslog